### PR TITLE
Fix bugs with Boolean atoms (t/f) and operators

### DIFF
--- a/hoa/ast/boolean_expression.py
+++ b/hoa/ast/boolean_expression.py
@@ -222,7 +222,7 @@ def _simplify_monotone_op_operands(cls, *operands):
     elif len(operands) == 1:
         return (operands[0],)
     elif cls._absorbing in operands:
-        return cls._absorbing
+        return (cls._absorbing,)
 
     # shift-up subformulas with same operator. DFS on expression tree.
     new_operands = []

--- a/hoa/ast/boolean_expression.py
+++ b/hoa/ast/boolean_expression.py
@@ -55,44 +55,6 @@ class UnaryOp(Generic[T]):
         return f"{type(self).__name__}({repr(self.argument)})"
 
 
-@dataclass(order=True, unsafe_hash=True, frozen=True)
-class TrueFormula:
-    """A tautology."""
-
-    def __str__(self) -> str:
-        """Get the string representation."""
-        return "(true)"
-
-    def __repr__(self) -> str:
-        """Get an unambiguous string representation."""
-        return "TrueFormula()"
-
-    def __neg__(self) -> "FalseFormula":
-        """Negate."""
-        return FALSE
-
-
-@dataclass(order=True, unsafe_hash=True, frozen=True)
-class FalseFormula:
-    """A contradiction."""
-
-    def __str__(self) -> str:
-        """Get the string representation."""
-        return "(false)"
-
-    def __repr__(self) -> str:
-        """Get an unambiguous string representation."""
-        return "FalseFormula()"
-
-    def __neg__(self) -> "TrueFormula":
-        """Negate."""
-        return TRUE
-
-
-TRUE = TrueFormula()
-FALSE = FalseFormula()
-
-
 class MonotoneOp(type):
     """Metaclass to simplify monotone operator instantiations."""
 
@@ -110,29 +72,95 @@ class MonotoneOp(type):
 class _And(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """And operator."""
 
-    _absorbing = FALSE
+    _absorbing = None
     SYMBOL = "&"
 
 
 class _Or(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """Or operator."""
 
-    _absorbing = TRUE
+    _absorbing = None
     SYMBOL = "|"
 
 
 class _PositiveAnd(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """And operator."""
 
-    _absorbing = FALSE
+    _absorbing = None
     SYMBOL = "&"
 
 
 class _PositiveOr(BinaryOp, Generic[T], metaclass=MonotoneOp):
     """Or operator."""
 
-    _absorbing = TRUE
+    _absorbing = None
     SYMBOL = "|"
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class TrueFormula:
+    """A tautology."""
+
+    def __str__(self) -> str:
+        """Get the string representation."""
+        return "(true)"
+
+    def __repr__(self) -> str:
+        """Get an unambiguous string representation."""
+        return "TrueFormula()"
+
+    def __and__(self, other):
+        """Return self & other."""
+        return _And(self, other)
+
+    def __or__(self, other):
+        """Return self | other."""
+        return _Or(self, other)
+
+    def __neg__(self) -> "FalseFormula":
+        """Negate."""
+        return FALSE
+
+    def __invert__(self) -> "FalseFormula":
+        """Negate."""
+        return FALSE
+
+
+@dataclass(order=True, unsafe_hash=True, frozen=True)
+class FalseFormula:
+    """A contradiction."""
+
+    def __str__(self) -> str:
+        """Get the string representation."""
+        return "(false)"
+
+    def __repr__(self) -> str:
+        """Get an unambiguous string representation."""
+        return "FalseFormula()"
+
+    def __and__(self, other):
+        """Return self & other."""
+        return _And(self, other)
+
+    def __or__(self, other):
+        """Return self | other."""
+        return _Or(self, other)
+
+    def __neg__(self) -> "TrueFormula":
+        """Negate."""
+        return TRUE
+
+    def __invert__(self) -> "TrueFormula":
+        """Negate."""
+        return TRUE
+
+
+TRUE = TrueFormula()
+FALSE = FalseFormula()
+_And._absorbing = FALSE
+_Or._absorbing = TRUE
+_PositiveAnd._absorbing = FALSE
+_PositiveOr._absorbing = TRUE
 
 
 class _Not(UnaryOp, Generic[T]):

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -17,7 +17,7 @@
 
 """This module contains the test for the 'hoa.ast.label' module."""
 
-from hoa.ast.boolean_expression import And, Not, Or
+from hoa.ast.boolean_expression import And, FalseFormula, Not, Or, TrueFormula
 from hoa.ast.label import LabelAlias, LabelAtom, propositions
 from hoa.types import alias
 
@@ -38,3 +38,37 @@ def test_propositions():
     assert isinstance(not_, Not)
 
     assert propositions(not_) == {0, 1, 2}
+
+
+def test_constants():
+    """Test the handling of t, f in Boolean operations."""
+    t = TrueFormula()
+    f = FalseFormula()
+
+    neg_t = -t
+    inv_t = ~t
+    neg_f = -f
+    inv_f = ~f
+
+    assert isinstance(neg_t, FalseFormula)
+    assert isinstance(inv_t, FalseFormula)
+    assert isinstance(neg_f, TrueFormula)
+    assert isinstance(inv_f, TrueFormula)
+
+    f_and_t = f & t
+    f_and_f = f & f
+    t_and_f = t & f
+    t_and_t = t & t
+    f_or_f = f | f
+    f_or_t = f | t
+    t_or_f = t | f
+    t_or_t = t | t
+
+    assert isinstance(f_and_f, FalseFormula)
+    assert isinstance(t_and_f, FalseFormula)
+    assert isinstance(f_and_t, FalseFormula)
+    assert isinstance(t_and_t, TrueFormula)
+    assert isinstance(f_or_f, FalseFormula)
+    assert isinstance(f_or_t, TrueFormula)
+    assert isinstance(t_or_f, TrueFormula)
+    assert isinstance(t_or_t, TrueFormula)


### PR DESCRIPTION
## Proposed changes

Some tools may output un-simplified HOA files, containing sub-expressions like `!f` or `t & ...` in its labels. `pyhoafparser` would routinely fail on such files, since its classes for Boolean atoms `TrueFormula`, `FalseFormula` did not implement the necessary functions to handle these cases.

## Fixes

Wrote some unit tests demonstrating how the previous implementation failed.

Implemented magic methods (`__and__`, `__or__`, `__invert__`) for `TrueFormula` and `FalseFormula`. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

This required some reordering of the declarations in `boolean_expressions.py` but those do not alter the API.