### PR TITLE
Fix handling of `tool` header

### DIFF
--- a/hoa/parsers.py
+++ b/hoa/parsers.py
@@ -228,7 +228,7 @@ class HOATransformer(Transformer):
 
     def tool(self, args):
         """Parse the 'tool' node."""
-        return HeaderItemType.TOOL, args[0]
+        return HeaderItemType.TOOL, tuple(x.strip('"') for x in args)
 
     def name(self, args):
         """Parse the 'nome' node."""

--- a/hoa/parsers.py
+++ b/hoa/parsers.py
@@ -228,7 +228,7 @@ class HOATransformer(Transformer):
 
     def tool(self, args):
         """Parse the 'tool' node."""
-        return HeaderItemType.TOOL, tuple(x.strip('"') for x in args)
+        return HeaderItemType.TOOL, tuple(args)
 
     def name(self, args):
         """Parse the 'nome' node."""

--- a/tests/examples/strix-Ga.hoa
+++ b/tests/examples/strix-Ga.hoa
@@ -1,0 +1,14 @@
+HOA: v1
+name: "G a"
+tool: "strix" "21.0.0"
+States: 2
+Start: 0
+AP: 1 "a"
+acc-name: all
+Acceptance: 0 t
+--BODY--
+State: 0 "[0]"
+[(t) & (0)] 1
+State: 1 "[1]"
+[(t) & (0)] 1
+--END--

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import pytest
 
 from hoa.ast.acceptance import Fin, Inf, nb_accepting_sets
-from hoa.ast.boolean_expression import TRUE, TrueFormula
+from hoa.ast.boolean_expression import TRUE, And, TrueFormula
 from hoa.ast.label import LabelAlias, LabelAtom
 from hoa.core import Acceptance, Edge, HOA, HOABody, HOAHeader, State
 from hoa.dumpers import dump
@@ -620,6 +620,44 @@ class TestParsingAut12:
             Edge([2, 3], label=LabelAtom(1))
         ]
         state_edges_dict[State(3, name=string("c"))] = [Edge([1], label=LabelAtom(2))]
+        hoa_body = HOABody(state_edges_dict)
+
+        hoa_obj = HOA(hoa_header, hoa_body)
+        assert self.hoa_obj == hoa_obj
+
+
+class TestParsingStrixGa:
+    """Test parsing for tests/examples/strix-Ga."""
+
+    @classmethod
+    def setup_class(cls):
+        """Set the test up."""
+        parser = HOAParser()
+        cls.hoa_obj: HOA = parser(
+            Path(TEST_ROOT_DIR, "examples", "strix-Ga.hoa").read_text()
+        )
+        cls.hoa_header = cls.hoa_obj.header
+        cls.hoa_body = cls.hoa_obj.body
+
+    def test_hoa(self):
+        """Test that the HOA automaton is correct."""
+        hoa_header = HOAHeader(
+            identifier("v1"),
+            Acceptance(TrueFormula(), "all"),
+            nb_states=2,
+            start_states={frozenset([0])},
+            propositions=(string("a"),),
+            tool=("strix", "21.0.0"),
+            name=string("G a"),
+        )
+
+        state_edges_dict = OrderedDict({})
+        state_edges_dict[State(0, name=string("[0]"))] = [
+            Edge([1], label=And(TrueFormula(), LabelAtom(0))),
+        ]
+        state_edges_dict[State(1, name=string("[1]"))] = [
+            Edge([1], label=And(TrueFormula(), LabelAtom(0))),
+        ]
         hoa_body = HOABody(state_edges_dict)
 
         hoa_obj = HOA(hoa_header, hoa_body)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -647,7 +647,7 @@ class TestParsingStrixGa:
             nb_states=2,
             start_states={frozenset([0])},
             propositions=(string("a"),),
-            tool=("strix", "21.0.0"),
+            tool=('"strix"', '"21.0.0"'),
             name=string("G a"),
         )
 


### PR DESCRIPTION
## Proposed changes

The (optional) `tool` header takes 1 or 2 strings. The second string, if present, indicates the version of the tool.
It is used, e.g., by `strix`:
```
tool: "strix" "21.0.0"
```

However, `pyhoafparser` would take a HOA with a header like the one above and output this:

```
tool: " s t r i x "
```


## Fixes

We fix the bug described above.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
